### PR TITLE
dpms: Log more information when platform detection fails

### DIFF
--- a/src/libdpms/dpms.cpp
+++ b/src/libdpms/dpms.cpp
@@ -15,7 +15,8 @@ KScreen::Dpms::Dpms(QObject *parent)
     if (QX11Info::isPlatformX11()) {
         m_helper.reset(new XcbDpmsHelper);
     } else {
-        qCWarning(KSCREEN_DPMS) << "dpms unsupported on this system";
+        qCWarning(KSCREEN_DPMS) << "Platform is not Wayland or X11, this doesn't make sense. Platform name is" << QGuiApplication::platformName();
+        Q_ASSERT(false);
         return;
     }
 


### PR DESCRIPTION
When we hit this codepath neither Wayland nor X11 were detected, we need to figure out how we ended up there

CCSENTRY: POWERDEVIL-4GF
(cherry picked from commit 3a216a20e96db5d8bf99f5b077e6ed49bda98ab9)